### PR TITLE
Add py.typed marker file for PEP 561 typing

### DIFF
--- a/openapi_schema_pydantic/py.typed
+++ b/openapi_schema_pydantic/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561


### PR DESCRIPTION
This is so that mypy will check the types declared in this project instead of complaining about missing types.