### PR TITLE
allow reference in parameter schema

### DIFF
--- a/openapi_schema_pydantic/v3/v3_1_0/parameter.py
+++ b/openapi_schema_pydantic/v3/v3_1_0/parameter.py
@@ -100,7 +100,7 @@ class Parameter(BaseModel):
     The default value is `false`.
     """
 
-    param_schema: Optional[Schema] = Field(default=None, alias="schema")
+    param_schema: Optional[Union[Schema, Reference]] = Field(default=None, alias="schema")
     """
     The schema defining the type used for the parameter.
     """


### PR DESCRIPTION
fixes issue where validation of parameter schema fails because it does not expect reference