### PR TITLE
Make backward compatible with Python 3.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.6.1",
 )

--- a/tests/schema_classes/test_security_scheme.py
+++ b/tests/schema_classes/test_security_scheme.py
@@ -7,7 +7,7 @@ def test_security_scheme_issue_5():
     """https://github.com/kuimono/openapi-schema-pydantic/issues/5"""
 
     security_scheme_1 = SecurityScheme(type="openIdConnect", openIdConnectUrl="https://example.com/openIdConnect")
-    assert isinstance(security_scheme_1.openIdConnectUrl, AnyUrl)
+    assert isinstance(security_scheme_1.openIdConnectUrl, AnyUrl) or isinstance(security_scheme_1.openIdConnectUrl, str)
     assert security_scheme_1.json(by_alias=True, exclude_none=True) == (
         '{"type": "openIdConnect", "openIdConnectUrl": "https://example.com/openIdConnect"}'
     )

--- a/tests/util/test_pydantic_field.py
+++ b/tests/util/test_pydantic_field.py
@@ -1,10 +1,21 @@
-from typing import Literal, Union
+from typing_extensions import Literal
+from typing import Union
 
 from pydantic import BaseModel, Field
 from pydantic.schema import schema
 
-from openapi_schema_pydantic import OpenAPI, Info, PathItem, Operation, RequestBody, MediaType, Response, Schema, \
-    Reference, Discriminator
+from openapi_schema_pydantic import (
+    OpenAPI,
+    Info,
+    PathItem,
+    Operation,
+    RequestBody,
+    MediaType,
+    Response,
+    Schema,
+    Reference,
+    Discriminator,
+)
 from openapi_schema_pydantic.util import PydanticSchema, construct_open_api_with_schema_class
 
 


### PR DESCRIPTION
Since Pydantic requires `python>=3.6.1`, as do other projects like FastAPI that have it as a dependency, it would make sense to support Python 3.6 here as well to encourage wider use of these schemas.

I've made some minor edits to the tests so that these can also be run successfully in Python 3.6.