### PR TITLE
Log via `Logger` objects.

### DIFF
--- a/openapi_schema_pydantic/__init__.py
+++ b/openapi_schema_pydantic/__init__.py
@@ -1,1 +1,6 @@
+import logging
+
 from .v3 import *
+
+
+logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
- Changes `logging.xxx(...)` to `logger.xxx(...)`
- Adds a null handler to library logging per example from https://docs.python.org/3/howto/logging.html#configuring-logging-for-a-library

Closes #19 