### PR TITLE
add pre-commit and update project setup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 120
+max-complexity = 12

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /.pytest_cache
 /build
 /dist
+/.venv
 __pycache__

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,59 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-ast
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: end-of-file-fixer
+        exclude: "\\.idea/(.)*"
+      - id: trailing-whitespace
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.34.0
+    hooks:
+      - id: pyupgrade
+        args: ["--py37-plus"]
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+  - repo: https://github.com/psf/black
+    rev: 22.3.0
+    hooks:
+      - id: black
+        args: [--config=./pyproject.toml]
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v2.7.1"
+    hooks:
+      - id: prettier
+  - repo: https://github.com/pycqa/bandit
+    rev: 1.7.4
+    hooks:
+      - id: bandit
+        exclude: "test_*"
+        args: ["-iii", "-ll", "-s=B308,B703"]
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.2
+    hooks:
+      - id: flake8
+        additional_dependencies:
+          [
+            "flake8-bugbear",
+            "flake8-comprehensions",
+            "flake8-mutable",
+            "flake8-print",
+            "flake8-simplify",
+          ]
+  - repo: https://github.com/pycqa/pylint
+    rev: "v2.14.3"
+    hooks:
+      - id: pylint
+        exclude: "test_*"
+        args: ["--unsafe-load-any-extension=y"]
+        additional_dependencies: [pydantic]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: "v0.961"
+    hooks:
+      - id: mypy
+        additional_dependencies: [pydantic]

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,12 @@
+[mypy]
+plugins = pydantic.mypy
+
+warn_unused_ignores = True
+warn_redundant_casts = True
+warn_unused_configs = True
+warn_unreachable = True
+warn_return_any = True
+strict = True
+disallow_any_generics = False
+implicit_reexport = False
+show_error_codes = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,21 +1,29 @@
 [tool.black]
 line-length = 120
-target-version = ['py38']
 include = '\.pyi?$'
-exclude = '''
-(
-  /(
-      \.eggs         # exclude a few common directories in the
-    | \.git          # root of the project
-    | \.hg
-    | \.mypy_cache
-    | \.tox
-    | \.venv
-    | _build
-    | buck-out
-    | build
-    | dist
-    | libs           # we have no obligation to format external libraries
-  )/
-)
-'''
+
+[tool.isort]
+profile = "black"
+multi_line_output = 3
+
+[tool.pylint.MESSAGE_CONTROL]
+disable = [
+    "pointless-string-statement",
+    "duplicate-code",
+    "missing-module-docstring",
+    "missing-class-docstring",
+    "too-few-public-methods",
+]
+enable = "useless-suppression"
+
+[tool.pylint.REPORTS]
+reports = "no"
+
+[tool.pylint.FORMAT]
+max-line-length = "120"
+
+[tool.pylint.VARIABLES]
+ignored-argument-names = "args|kwargs|_|__"
+
+[tool.pylint.BASIC]
+good-names = "_,i,e,fn"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # project dependencies
-pydantic==1.9.0
+pydantic==1.9.1
 
 # PyPi
 twine==3.8.0


### PR DESCRIPTION
This PR adds basic tooling for quality control. 

Background for this issue: the recent release that includes `py.typed` leads to a lot of errors downstream due to typing. This led me to check what kind of mypy settings are in this project, and it became clear that there are none in place. I therefore decided to contribute a `pre-commit` setup that will allow easy auditing and linting of the source code. 

How to use this:

1. install `pre-commit` by following the instructions in its website: https://pre-commit.com/, e.g. `brew install pre-commit`.
2. install the hooks locally by running `pre-commit install`
3. run the hooks against all files to see the errors that appear (there are a lot of them) -> `pre-commit run --all-files`

You can integrate pre-commit in CI and other components. Its the best tool of its class.

Notes:

* pylint, black and isort configs are in `pyproject.toml`
* mypy configs are in `mypy.ini`
* flake8 configs are in `.flake8`
